### PR TITLE
Use local buffer on stack.

### DIFF
--- a/src/i2c_impl.rs
+++ b/src/i2c_impl.rs
@@ -2,6 +2,7 @@ use i2c_gen as i2c;
 
 use std::os::unix::io::AsRawFd;
 use std::io;
+use std::mem;
 use resize_slice::ResizeSlice;
 use i2c_gen::{ReadFlags as I2cReadFlags, WriteFlags as I2cWriteFlags};
 use super::{I2c, ReadFlags, WriteFlags, ReadWrite};
@@ -86,9 +87,12 @@ impl<I: AsRawFd> i2c::BulkTransfer for I2c<I> {
     }
 
     fn i2c_transfer(&mut self, messages: &mut [i2c::Message]) -> Result<(), Self::Error> {
-        assert!(messages.len() <= self.message_buffer.len());
+        let mut message_buffer: [::i2c::i2c_msg; ::i2c::I2C_RDWR_IOCTL_MAX_MSGS] = unsafe {
+            mem::zeroed()
+        };
+        assert!(messages.len() <= message_buffer.len());
 
-        self.message_buffer.iter_mut().zip(messages.iter_mut())
+        message_buffer.iter_mut().zip(messages.iter_mut())
             .for_each(|(out, msg)| *out = match *msg {
                 i2c::Message::Read { address, ref mut data, flags } => ::i2c::i2c_msg {
                     addr: address,
@@ -105,10 +109,10 @@ impl<I: AsRawFd> i2c::BulkTransfer for I2c<I> {
             });
 
         let res = unsafe {
-            ::i2c::i2c_rdwr(self.as_raw_fd(), &mut self.message_buffer[..messages.len()])?;
+            ::i2c::i2c_rdwr(self.as_raw_fd(), &mut message_buffer[..messages.len()])?;
         };
 
-        self.message_buffer.iter().zip(messages.iter_mut())
+        message_buffer.iter().zip(messages.iter_mut())
             .for_each(|(msg, out)| match *out {
                 i2c::Message::Read { ref mut data, .. } => data.resize_to(msg.len as usize),
                 i2c::Message::Write { .. } => (),

--- a/src/i2c_impl.rs
+++ b/src/i2c_impl.rs
@@ -88,7 +88,7 @@ impl<I: AsRawFd> i2c::BulkTransfer for I2c<I> {
 
     fn i2c_transfer(&mut self, messages: &mut [i2c::Message]) -> Result<(), Self::Error> {
         let mut message_buffer: [::i2c::i2c_msg; ::i2c::I2C_RDWR_IOCTL_MAX_MSGS] = unsafe {
-            mem::zeroed()
+            mem::uninitialized()
         };
         assert!(messages.len() <= message_buffer.len());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl<I: AsRawFd> I2c<I> {
     /// See the `I2C_RDWR` ioctl for more information.
     pub fn i2c_transfer(&mut self, messages: &mut [Message]) -> io::Result<()> {
         let mut message_buffer: [i2c::i2c_msg; i2c::I2C_RDWR_IOCTL_MAX_MSGS] = unsafe {
-            mem::zeroed()
+            mem::uninitialized()
         };
         assert!(messages.len() <= message_buffer.len());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,6 @@ bitflags! {
 /// A safe wrapper around an I2C device.
 pub struct I2c<I> {
     inner: I,
-    message_buffer: Box<[i2c::i2c_msg; i2c::I2C_RDWR_IOCTL_MAX_MSGS]>,
     address: Option<u16>,
     address_10bit: bool,
     functionality: Option<Functionality>,
@@ -169,7 +168,6 @@ impl<I> I2c<I> {
     pub fn new(device: I) -> Self {
         I2c {
             inner: device,
-            message_buffer: Box::new(unsafe { mem::zeroed() }),
             address: None,
             address_10bit: false,
             functionality: None,
@@ -291,9 +289,12 @@ impl<I: AsRawFd> I2c<I> {
     ///
     /// See the `I2C_RDWR` ioctl for more information.
     pub fn i2c_transfer(&mut self, messages: &mut [Message]) -> io::Result<()> {
-        assert!(messages.len() <= self.message_buffer.len());
+        let mut message_buffer: [i2c::i2c_msg; i2c::I2C_RDWR_IOCTL_MAX_MSGS] = unsafe {
+            mem::zeroed()
+        };
+        assert!(messages.len() <= message_buffer.len());
 
-        self.message_buffer.iter_mut().zip(messages.iter_mut())
+        message_buffer.iter_mut().zip(messages.iter_mut())
             .for_each(|(out, msg)| *out = match *msg {
                 Message::Read { address, ref mut data, flags } => i2c::i2c_msg {
                     addr: address,
@@ -310,10 +311,10 @@ impl<I: AsRawFd> I2c<I> {
             });
 
         let res = unsafe {
-            i2c::i2c_rdwr(self.as_raw_fd(), &mut self.message_buffer[..messages.len()])?;
+            i2c::i2c_rdwr(self.as_raw_fd(), &mut message_buffer[..messages.len()])?;
         };
 
-        self.message_buffer.iter().zip(messages.iter_mut())
+        message_buffer.iter().zip(messages.iter_mut())
             .for_each(|(msg, out)| match *out {
                 Message::Read { ref mut data, .. } => data.resize_to(msg.len as usize),
                 Message::Write { .. } => (),


### PR DESCRIPTION
This allows `I2c` to be send across threads.

Previously it failed with

> `*mut u8` cannot be sent between threads safely

because a `*mut u8` pointer is part of the boxed `i2c_msg` buffer within `I2c`. This buffer is now removed and instead `i2c_transfer()` creates a local buffer on the stack.