### PR TITLE
Updates deps, edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "i2c-linux"
 version = "0.1.2"
 authors = ["arcnmx"]
+edition = "2018"
 
 description = "Linux I2C device interface"
 keywords = ["i2c", "i2c-dev", "i2cdev", "smbus"]
@@ -16,11 +17,11 @@ travis-ci = { repository = "arcnmx/i2c-linux-rs" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-i2c-linux-sys = "^0.2.0"
-resize-slice = "^0.1.2"
-bitflags = "^1.0.1"
-i2c = { version = "^0.1.0", optional = true }
-udev = { version = "^0.2.0", optional = true }
+i2c-linux-sys = "0"
+resize-slice = "0"
+bitflags = "1"
+i2c = { version = "0", optional = true }
+udev = { version = "0", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This udpates the rust edition to 2018 and fixes clippy/fmt warnings.

Ideally goes out with https://github.com/arcnmx/i2c-linux-sys-rs/pull/1 once that's published on crates